### PR TITLE
Prevent SHViewPager from blocking tap to scroll to top gestures in sub views 

### DIFF
--- a/SHViewPager/SHViewPager.m
+++ b/SHViewPager/SHViewPager.m
@@ -102,7 +102,11 @@
     
     UISwipeGestureRecognizer *leftSwipe = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(leftSwipeAction:)];
     leftSwipe.direction = UISwipeGestureRecognizerDirectionLeft;
-    
+
+    // Prevent SHViewPager from blocking tap to scroll to top gestures in sub views    
+    topTabScroll.scrollsToTop = NO;
+    contentScroll.scrollsToTop = NO;
+
     [self addSubview:topTabScroll];
     [self addSubview:indexIndicatorImageView];
     [self addSubview:headerTitleLabel];


### PR DESCRIPTION
The UIScrollViews within SHViewPager were blocking the tap to scroll to top gesture getting to any sub views contained in the pages. i.e. if a page contained a UITableViewController then the table was not scrolling to the top when the gesture was triggered.